### PR TITLE
Fix for lifecycle events / mac scripts & --no-arguments option

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -32,15 +32,17 @@
    * it also helps to group similar platforms on a single execution
    */
   switch (platform) {
-    case 'win32': result = (`${script}:windows` in scripts) ? `${script}:windows` : false;
-
+    case 'win32':
+        result = (`${script}:windows` in scripts) ? `${script}:windows` : false;
+        break;
     case 'aix':
     case 'linux':
     case 'sunos':
     case 'openbsd':
     case 'freebsd':
-    case 'android': result = (`${script}:nix` in scripts) ? `${script}:nix` : false;
-
+    case 'android':
+        result = (`${script}:nix` in scripts) ? `${script}:nix` : false;
+        break;
     case 'darwin':
       /**
        * macOS specific scripts (e.g. brew)
@@ -53,10 +55,8 @@
       if(!result) {
         result = (`${script}:nix` in scripts) ? `${script}:nix` : false;
 	  }
-
       break;
-
-    default: return false;
+    default: result = false;
   }
 
   /**

--- a/functions.js
+++ b/functions.js
@@ -62,5 +62,9 @@
   /**
    * Test if no script could be matched and try to return the default
    */
-  return result ? result : (`${script}:default` in scripts);
+  if(result){
+      return result;
+  }
+  
+  return (`${script}:default` in scripts) ? `${script}:default` : false;
 };

--- a/functions.js
+++ b/functions.js
@@ -9,6 +9,15 @@
   */
  exports.matchScript = function matchScript(script, platform, scripts) {
   /**
+   * Save the result so we can determine if there was a match
+   * First check for a basic match before we have to go through each script with a regex
+   */
+  let result = (`${script}:${platform}` in scripts) ? `${script}:${platform}` : false;
+  if(result){
+    return result;
+  }
+  
+  /**
    * Regular expresion match
    * it helps when the "in" operator can't determine if there's a real match or not,
    * due to the properties changing
@@ -17,11 +26,6 @@
   for (let command in scripts) {
     if (command.match(regex)) return command;
   }
-
-  /**
-   * Save the result so we can determine if there was a match
-   */
-  let result;
 
   /**
    * Alias match, allows for a more verbose description of the platform
@@ -41,14 +45,14 @@
       /**
        * macOS specific scripts (e.g. brew)
        */
-      if (script === 'darwin')
-        result = (`${script}:darwin` in scripts) ? `${script}:darwin` : false;
+      result = (`${script}:darwin` in scripts) ? `${script}:darwin` : false;
 
       /**
        * nix compatible scripts (cp, rm...)
        */
-      else if (script === 'nix')
-        result = (`${script}:nix`    in scripts) ? `${script}:nix`    : false;
+      if(!result) {
+        result = (`${script}:nix` in scripts) ? `${script}:nix` : false;
+	  }
 
       break;
 
@@ -58,7 +62,5 @@
   /**
    * Test if no script could be matched and try to return the default
    */
-  if (!result) {
-    return (`${script}:default` in scripts) ? `${script}:default` : false;
-  }
-}
+  return result ? result : (`${script}:default` in scripts);
+};

--- a/index.js
+++ b/index.js
@@ -54,31 +54,17 @@ if (process.env.npm_config_user_agent.includes('yarn') && !argument) {
 }
 
 /**
- * Prepare command structure to test the available scripts defined in "scripts: { ... }"
- */
-let osCommand = `${options[1]}:${platform}`;
-
-/**
- * Basic match upon the property name
- * determine wether the name of the script exists in the list of defined scripts
- */
-let foundMatch = osCommand in scripts;
-
-if (!foundMatch) {
-  /**
    * More in-depth match
    * Execute the regular expression to help identify missing scripts
    * It also tests for different aliases
-   */
-  osCommand = matchScript(argument, platform, scripts) || matchScript(event, platform, scripts);
-  foundMatch = !!osCommand;
-}
+ */
+let osCommand = matchScript(event || argument, platform, scripts);
 
 /**
  * Test again, this time to end the process gracefully
  */
-if (!foundMatch) {
-  console.log(`run-script-os was unable to execute the script '${osCommand}'`);
+if (!osCommand) {
+  console.log(`run-script-os was unable to execute the script '${event || argument}'`);
   process.exit(0);
 }
 
@@ -93,6 +79,15 @@ if (!(options[0] === "run" || options[0] === "run-script")) {
  * Lastly, set the script to be executed
  */
 options[1] = osCommand;
+
+/**
+ * Check if we should be passing the original arguments to the new script
+ * Fix for #23
+ */
+const args = process.argv.slice(2).map((a) => a.toLowerCase());
+if(args.includes('--no-arguments')){
+  options = options.slice(0,2);
+}
 
 /**
  * Spawn new process to run the required script

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "run-script-os",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "run-script-os is a tool that will let you use generic npm script commands that will pass through to os specific commands.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
It looked like this was the preferred fork for lifecycle events - I ran into some issues with scripts on the mac and with the second argument in the original command ("version" in "npm version patch") overriding the lifecycle event ("postversion"). 

Small refactor to give npm_lifecycle_event priority over npm_config_argv to support lifecycle events.

Fixed an issue with no scripts found on mac (darwin or nix)

Also, added --no-arguments option to fix https://github.com/charlesguse/run-script-os/issues/23